### PR TITLE
Fixed mod version checking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ pub fn find_correct_version(id: &String, target: &Version) -> Result<ModFile, Er
         Error::new(
             ErrorKind::NotFound,
             format!(
-                "could not find version that satisfies target {} and loader paper",
+                "could not find version that satisfies target {} and fabric loader",
                 target
             )
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 pub mod structs;
 use crate::structs::*;
 use std::env;
-use std::io::{Read, Write};
+use std::io::{Error, ErrorKind, Read, Write};
 use pbr::{ProgressBar, Units};
 use colored::*;
 use inquire::{Text, Confirm};
 use attohttpc::get;
-use semver::{Version,VersionReq};
+use semver::{Version, VersionReq};
 use crossterm::terminal::{Clear, ClearType};
 
 fn parse_config() -> Options {
@@ -42,7 +42,7 @@ fn print_mod(mcmod: &MinecraftMod) {
     println!("");
 }
 
-pub fn search_mods(query: &String) -> Result<MinecraftMods, std::io::Error> {
+pub fn search_mods(query: &String) -> Result<MinecraftMods, Error> {
     let mut mods: MinecraftMods = get("https://api.modrinth.com/api/v1/mod")
         .param("query", &query)
         .send()?
@@ -53,32 +53,54 @@ pub fn search_mods(query: &String) -> Result<MinecraftMods, std::io::Error> {
     Ok(mods)
 }
 
-pub fn find_correct_version(id: &String, target: &Version) -> Result<ModFile, std::io::Error> {
-    let url = format!("https://api.modrinth.com/api/v1/mod/{}/version", id);
-    let versions: Vec<ModVersion> = get(url)
+pub fn find_correct_version(id: &String, target: &Version) -> Result<ModFile, Error> {
+    let url: String = format!("https://api.modrinth.com/api/v1/mod/{}/version", id);
+    let mod_versions: Vec<ModVersion> = get(url)
         .send()?
         .json()?;
 
-    for version in versions {
-        if !version.loaders.contains(&"fabric".into()) {
-            continue
-        }
-        let found = version
-            .versions
+    for mod_version in mod_versions {
+        if !mod_version.loaders.contains(&"fabric".into()) { continue; }
+
+        let found_version_index: Option<usize> = mod_version
+            .game_versions
             .iter()
-            .any(|ver| match VersionReq::parse(ver) {
-                Ok(ver) => ver.matches(&target),
-                Err(_) => false,
+            .position(|ver| {
+                let attempt = VersionReq::parse(format!("={}", ver).as_str());
+                match attempt {
+                    Ok(parsed_ver) => parsed_ver.matches(&target),
+                    Err(_) => false
+                }
             });
-        if found {
-            return Ok(version.files.get(0).unwrap().to_owned());
+
+        match found_version_index {
+            Some(idx) => {
+                let message: ColoredString = format!(
+                    "found {} {} for {}",
+                    mod_version.version_type,
+                    mod_version.version_number,
+                    target
+                ).italic().bright_black();
+
+                println!("{}", message);
+                return Ok(mod_version.files[idx].to_owned());
+            },
+            None => { continue; }
         }
     }
- 
-    Err(std::io::Error::new(std::io::ErrorKind::NotFound, "cant find correct version"))
+
+    Err(
+        Error::new(
+            ErrorKind::NotFound,
+            format!(
+                "could not find version that satisfies target {} and loader paper",
+                target
+            )
+        )
+    )
 }
 
-fn install<T: std::io::Write>(url: &String, filename: &String, mut bar: ProgressBar<T>) -> Result<(), std::io::Error> {
+fn install<T: std::io::Write>(url: &String, filename: &String, mut bar: ProgressBar<T>) -> Result<(), Error> {
     let res = get(&url).send()?;
     let (_, headers, mut body) = res.split();
     let len = headers
@@ -117,7 +139,7 @@ fn install<T: std::io::Write>(url: &String, filename: &String, mut bar: Progress
     Ok(())
 }
 
-fn install_single(id: &String, target: &Version) -> Result<OptionMod, std::io::Error> {
+fn install_single(id: &String, target: &Version) -> Result<OptionMod, Error> {
     let bullseye = find_correct_version(&id, &target)?;
     let ModFile { url, filename } = bullseye;
     let bar = ProgressBar::new(0);
@@ -131,7 +153,7 @@ fn install_single(id: &String, target: &Version) -> Result<OptionMod, std::io::E
     })
 }
 
-fn install_pack(mods: &Vec<OptionMod>) -> Result<(), std::io::Error> {
+fn install_pack(mods: &Vec<OptionMod>) -> Result<(), Error> {
     println!("{}", "downloading mods".bright_cyan());
 
     for m in mods {
@@ -188,7 +210,7 @@ fn find_mod(query: &str, mods: &MinecraftMods, options: &Options) -> Option<ModS
     None
 }
 
-fn main() -> Result<(), std::io::Error> {
+fn main() -> Result<(), Error> {
     let (subcommand, query) = get_command();
     let mut options = parse_config();
     match subcommand.as_str() {
@@ -225,7 +247,7 @@ fn main() -> Result<(), std::io::Error> {
                     println!("already installed!");
                 },
                 None => {
-                    println!("{} no mods", "error:".bold().red());
+                    println!("{} no mods found", "error:".bold().red());
                 },
             };
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,17 +74,7 @@ pub fn find_correct_version(id: &String, target: &Version) -> Result<ModFile, Er
             });
 
         match found_version_index {
-            Some(idx) => {
-                let message: ColoredString = format!(
-                    "found {} {} for {}",
-                    mod_version.version_type,
-                    mod_version.version_number,
-                    target
-                ).italic().bright_black();
-
-                println!("{}", message);
-                return Ok(mod_version.files[idx].to_owned());
-            },
+            Some(idx) => { return Ok(mod_version.files[idx].to_owned()); },
             None => { continue; }
         }
     }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -30,9 +30,9 @@ pub struct MinecraftMod {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ModVersion {
-    #[serde(rename = "game_versions")]
-    pub versions: Vec<String>,
-    
+    pub game_versions: Vec<String>,
+    pub version_number: String,
+    pub version_type: String,
     pub loaders: Vec<String>,
     pub files: Vec<ModFile>,
 }


### PR DESCRIPTION
- made version checking stricter by adding "=" to the start of a mod's
  version when comparing to target version
- added message indicating the found mod version number and game version
  number in install command
- some code cleanup
- added and renamed versions in structs::ModVersion for clarity

I found an issue where attempting to install a mod that supports up to MC 1.16.3 while my target version is 1.17.1 would succeed. This would cause an incompatible mod to exist in the mods folder and crash the game. This PR aims to fix this issue by more strictly checking the mod's version against the target, and stopping if no compatible versions are found.